### PR TITLE
Fix balContractNumber for strings with leading/trailing whitespaces

### DIFF
--- a/packages/pipes/src/balContractNumber.spec.ts
+++ b/packages/pipes/src/balContractNumber.spec.ts
@@ -13,4 +13,7 @@ describe('balPoliceNumber', () => {
   test('should format a claim number with a sign postfix correctly', () => {
     expect(balContractNumber('0501222333')).toBe('50/1.222.333')
   })
+  test('should format a claim number with a leading or trailing whitespace correctly', () => {
+    expect(balContractNumber(' 0501222333 ')).toBe('50/1.222.333')
+  })
 })

--- a/packages/pipes/src/balContractNumber.ts
+++ b/packages/pipes/src/balContractNumber.ts
@@ -9,7 +9,7 @@ export function balContractNumber(value: string | undefined | null | number): st
   if (!value) {
     return ''
   }
-  let newValue = `${value}`
+  let newValue = (`${value}`).trim();
   if (newValue[0] !== '0') {
     newValue = `0${value}`
   }


### PR DESCRIPTION
Trim whitespaces after argument is converted to string