### PR TITLE
Fix validateConditionally

### DIFF
--- a/packages/validators/src/validateConditionally.validators.ts
+++ b/packages/validators/src/validateConditionally.validators.ts
@@ -10,6 +10,6 @@ import { BalValidatorFn } from './validator.type'
  */
 export function validateConditionally(validatorFn: BalValidatorFn, conditionFn: BalValidatorFn): BalValidatorFn {
   return function (value: any) {
-    return !conditionFn(value) ? undefined : validatorFn(value)
+    return !conditionFn(value) ? true : validatorFn(value)
   }
 }


### PR DESCRIPTION
Problem:

validateConditionally from Angular Validators uses the "standard" validateConditionally internally and calls the "standard" validate function afterwards.

"Standard" validate expects true for valid value. But validateConditionally returns "undefined" when valid.

The other JS validators in web-app-utils also return true for a valid value.