### PR TITLE
fix(validators): number validator will also accept a number string

### DIFF
--- a/packages/validators/src/number.validators.spec.ts
+++ b/packages/validators/src/number.validators.spec.ts
@@ -1,6 +1,14 @@
-import { isMin, isMax, isMonetaryNumber } from './number.validators'
+import { isMin, isMax, isMonetaryNumber, isNumber } from './number.validators'
 
 describe('number', () => {
+  test('isNumber', () => {
+    expect(isNumber()(0)).toBe(true)
+    expect(isNumber()(5)).toBe(true)
+    expect(isNumber()('5')).toBe(true)
+    expect(isNumber()('0')).toBe(true)
+    expect(isNumber()('test')).toBe(false)
+  })
+
   test('isMin', () => {
     expect(isMin(0)(0)).toBe(true)
     expect(isMin(10)(9)).toBe(false)

--- a/packages/validators/src/number.validators.ts
+++ b/packages/validators/src/number.validators.ts
@@ -52,6 +52,7 @@ export function isMax(max: number): BalValidatorFn {
  *
  * ```typescript
  * BalValidators.isNumber()(10) // true
+ * BalValidators.isNumber()('10') // true
  * BalValidators.isNumber()('a') // false
  * ```
  */
@@ -59,6 +60,9 @@ export function isNumber(): BalValidatorFn {
   return function (value: any) {
     if (isEmpty(value)) {
       return true
+    }
+    if (typeof value === 'string' && new RegExp(/^\d*$/).test(value)) {
+      return _isNumber(+value)
     }
     return _isNumber(value)
   }


### PR DESCRIPTION
The number validator did not accept number strings (e.g. '10') before. That led to issues when used with forms validations in our Angular applications. It will now accept number strings.
#32 