### PR TITLE
NLP-12627: balHighlight not highlighting parts of href

### DIFF
--- a/packages/pipes/src/balHighlight.spec.ts
+++ b/packages/pipes/src/balHighlight.spec.ts
@@ -8,4 +8,14 @@ describe('balHighlight', () => {
   test('should return same text without search query', () => {
     expect(balHighlight('search text', '')).toBe('search text')
   })
+  test('should highlight only text, not the text inside href', () => {
+    expect(
+      balHighlight(
+        `<a href="localhost:4200/mybaloise-api/api/documents/v1/12345678-1234-4321-1234-123456789012-12345678?filename=Vertrag" target="_blank">Vertrag</a>`,
+        'Vertrag',
+      ),
+    ).toBe(
+      `<a href="localhost:4200/mybaloise-api/api/documents/v1/12345678-1234-4321-1234-123456789012-12345678?filename=Vertrag" target="_blank"><span class="bal-highlight">Vertrag</span></a>`,
+    )
+  })
 })

--- a/packages/pipes/src/balHighlight.ts
+++ b/packages/pipes/src/balHighlight.ts
@@ -7,7 +7,10 @@
  */
 export function balHighlight(value: string, search: string, cssClass = 'bal-highlight'): string {
   if (search && value) {
-    let pattern = search.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+    let hrefTag = '(href=\"[^>]+\")|('
+    let pattern = hrefTag
+      .concat(search.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'))
+      .concat(')')
     pattern = pattern
       .split(' ')
       .filter(t => {
@@ -15,7 +18,9 @@ export function balHighlight(value: string, search: string, cssClass = 'bal-high
       })
       .join('|')
     const regex = new RegExp(pattern, 'gi')
-    return value.replace(regex, match => `<span class="${cssClass}">${match}</span>`)
+    return value.replace(regex, match => {
+      return match.includes('href') ? match : `<span class="bal-highlight">${match}</span>`
+    })
   } else {
     return value
   }

--- a/packages/pipes/src/balHighlight.ts
+++ b/packages/pipes/src/balHighlight.ts
@@ -7,10 +7,8 @@
  */
 export function balHighlight(value: string, search: string, cssClass = 'bal-highlight'): string {
   if (search && value) {
-    let hrefTag = '(href=\"[^>]+\")|('
-    let pattern = hrefTag
-      .concat(search.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'))
-      .concat(')')
+    const hrefTag = '(href="[^>]+")|('
+    let pattern = hrefTag.concat(search.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')).concat(')')
     pattern = pattern
       .split(' ')
       .filter(t => {
@@ -19,7 +17,7 @@ export function balHighlight(value: string, search: string, cssClass = 'bal-high
       .join('|')
     const regex = new RegExp(pattern, 'gi')
     return value.replace(regex, match => {
-      return match.includes('href') ? match : `<span class="bal-highlight">${match}</span>`
+      return match.includes('href') ? match : `<span class="${cssClass}">${match}</span>`
     })
   } else {
     return value


### PR DESCRIPTION
We have following issue:
- we get html message from the BE, and then we do balHighlight on that
- if you search for part of the href (for example name of the document), then url will get messed up and not work anymore (since span is injected in href)

This solution should solve that issue.

Issue in Jira:
https://jira.baloisenet.com/browse/NLP-12627