### PR TITLE
fix: Summary of Changes

### DIFF
--- a/packages/pipes-angular/.build/generator.script.cjs
+++ b/packages/pipes-angular/.build/generator.script.cjs
@@ -1,0 +1,50 @@
+/**
+ * angular - pipes
+ * --------------------------------------
+ * This script reads the pipes.json and creates
+ * out of this information the pipess.ts file, which
+ * adds the pipes to the angular framework.
+ */
+
+const path = require('path')
+const file = require('../../../.build/file')
+const { title } = require('../../../.build/log')
+const utilities = require('../../../.build/utilities')
+
+const run = async () => {
+  await title('angular : pipes')
+  const files = await utilities.read({ fileName: 'pipes' })
+  const pipes = files.map(f => f.functions[0])
+
+  const functions = pipes.map(f => f.name)
+  const utilPipes = pipes.map(f => `  ${f.name.charAt(0).toUpperCase() + f.name.slice(1)}Pipe`)
+  const utilPipesClass = pipes.map(f =>
+    [
+      '@Pipe({',
+      `  name: '${f.name}'`,
+      '})',
+      `export class ${f.name.charAt(0).toUpperCase() + f.name.slice(1)}Pipe implements PipeTransform {`,
+      `  transform = ${f.name}`,
+      '}',
+      '',
+    ].join('\n'),
+  )
+
+  const content = [
+    '// generated file by .build/generator.script.js',
+    '',
+    `import { Pipe, PipeTransform } from '@angular/core';`,
+    `import {`,
+    `  ${functions.join(',\n  ')}`,
+    `} from '@baloise/web-app-pipes'`,
+    '',
+    utilPipesClass.join('\n'),
+    'export const PIPES = [',
+    utilPipes.join(',\n'),
+    ']',
+  ].join('\n')
+
+  await file.save(path.join(__dirname, '../src/pipes.ts'), content)
+}
+
+run()

--- a/packages/pipes-angular/package.json
+++ b/packages/pipes-angular/package.json
@@ -23,7 +23,7 @@
     "banner": "node ../../.build/banner.js pipes-angular",
     "update:registry": "sed -i -e \"s#nexus.balgroupit.com/repository/npm#registry.npmjs.org#g\" package-lock.json\n",
     "build": "npm run banner && npm run clean && npm run build:generator && npm run build:compile",
-    "build:generator": "node .build/generator.script.js",
+    "build:generator": "node .build/generator.script.cjs",
     "build:compile": "ng-packagr -p ng-package.json",
     "clean": "rimraf src/pipes.ts && rimraf dist"
   },

--- a/packages/pipes-angular/package.json
+++ b/packages/pipes-angular/package.json
@@ -55,11 +55,23 @@
   "files": [
     "dist/"
   ],
-  "main": "dist/fesm2020/baloise-web-app-pipes-angular.mjs",
-  "module": "dist/fesm2015/baloise-web-app-pipes-angular.js",
+  "type": "module",
+  "main": "dist/fesm2022/baloise-web-app-pipes-angular.mjs",
+  "module": "dist/fesm2022/baloise-web-app-pipes-angular.mjs",
   "es2015": "dist/fesm2015/baloise-web-app-pipes-angular.mjs",
   "es2020": "dist/fesm2020/baloise-web-app-pipes-angular.mjs",
   "esm2020": "dist/esm2020/baloise-web-app-pipes-angular.mjs",
   "typings": "dist/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "esm2022": "./dist/esm2022/baloise-web-app-pipes-angular.mjs",
+      "esm": "./dist/esm2022/baloise-web-app-pipes-angular.mjs",
+      "default": "./dist/fesm2022/baloise-web-app-pipes-angular.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  }
 }

--- a/packages/validators-angular/.build/generator.script.cjs
+++ b/packages/validators-angular/.build/generator.script.cjs
@@ -1,0 +1,46 @@
+const path = require('path')
+const file = require('../../../.build/file')
+const { title } = require('../../../.build/log')
+const utilities = require('../../../.build/utilities')
+
+const run = async () => {
+  await title('angular : validators')
+  const files = await utilities.read({ fileName: 'validators' })
+  const validators = files
+    .reduce((acc, f) => {
+      return [...acc, ...f.functions]
+    }, [])
+    .map(v => {
+      const params = v.parameters.map(p => `${p.name}: ${p.type}`)
+      params.push(`errorName = '${v.name}'`)
+      return `
+ export function ${v.name}(${params.join(', ')}): ValidatorFn {
+   return (control: AbstractControl): { [key: string]: any } | null => {
+     return validate(BalValidators.${v.name}(${v.parameters.map(p => p.name).join(', ')})(control.value), errorName, control)
+   }
+ }`
+    })
+
+  const content = [
+    '// generated file by .build/generator.script.js',
+    '',
+    `import { AbstractControl, ValidatorFn } from '@angular/forms';`,
+    `import { BalValidators, BalValidatorFn } from '@baloise/web-app-validators'`,
+    `
+ function createError(key: string, control: AbstractControl) {
+   return {
+     [\`\${key}\`]: { value: control.value },
+   }
+ }
+
+ function validate(result: boolean, key: string, control: AbstractControl) {
+   return result === undefined || result === true ? null : createError(key, control)
+ }`,
+    validators.join('\n'),
+    '',
+  ].join('\n')
+
+  await file.save(path.join(__dirname, '../src/validators.ts'), content)
+}
+
+run()

--- a/packages/validators-angular/package.json
+++ b/packages/validators-angular/package.json
@@ -23,7 +23,7 @@
     "banner": "node ../../.build/banner.js validators-angular",
     "update:registry": "sed -i -e \"s#nexus.balgroupit.com/repository/npm#registry.npmjs.org#g\" package-lock.json\n",
     "build": "npm run banner && npm run clean && npm run build:generator && npm run build:compile",
-    "build:generator": "node .build/generator.script.js",
+    "build:generator": "node .build/generator.script.cjs",
     "build:compile": "ng-packagr -p ng-package.json",
     "clean": "rimraf src/validators.ts && rimraf dist"
   },

--- a/packages/validators-angular/package.json
+++ b/packages/validators-angular/package.json
@@ -56,11 +56,23 @@
   "files": [
     "dist/"
   ],
-  "main": "dist/fesm2020/baloise-web-app-validators-angular.mjs",
-  "module": "dist/fesm2015/baloise-web-app-validators-angular.js",
+  "type": "module",
+  "main": "dist/fesm2022/baloise-web-app-validators-angular.mjs",
+  "module": "dist/fesm2022/baloise-web-app-validators-angular.mjs",
   "es2015": "dist/fesm2015/baloise-web-app-validators-angular.mjs",
   "es2020": "dist/fesm2020/baloise-web-app-validators-angular.mjs",
   "esm2020": "dist/esm2020/baloise-web-app-validators-angular.mjs",
   "typings": "dist/index.d.ts",
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "esm2022": "./dist/esm2022/baloise-web-app-validators-angular.mjs",
+      "esm": "./dist/esm2022/baloise-web-app-validators-angular.mjs",
+      "default": "./dist/fesm2022/baloise-web-app-validators-angular.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  }
 }


### PR DESCRIPTION
     ✅ @baloise/web-app-validators-angular (validators-angular/package.json)
     Updated main: dist/fesm2020/baloise-web-app-validators-angular.mjs → dist/fesm2022/baloise-web-app-validators-angular.mjs
     Updated module: dist/fesm2015/baloise-web-app-validators-angular.js → dist/fesm2022/baloise-web-app-validators-angular.mjs
     Added "type": "module" for ES module support
     Added exports field with proper subpath exports for modern bundlers
     ✅ @baloise/web-app-pipes-angular (pipes-angular/package.json)
     Updated main: dist/fesm2020/baloise-web-app-pipes-angular.mjs → dist/fesm2022/baloise-web-app-pipes-angular.mjs
     Updated module: dist/fesm2015/baloise-web-app-pipes-angular.js → dist/fesm2022/baloise-web-app-pipes-angular.mjs
     Added "type": "module" for ES module support
     Added exports field with proper subpath exports for modern bundlers
     These changes ensure that:
     Modern bundlers (esbuild, Angular 17+) can properly resolve these packages
     The correct fesm2022 paths are used instead of the non-existent fesm2020/fesm2015 files
     The exports field provides proper entry point configuration for different module formats
     Type definitions are correctly exposed via the types field

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
